### PR TITLE
tools unspaghettification

### DIFF
--- a/src/autotiles.lua
+++ b/src/autotiles.lua
@@ -45,29 +45,29 @@ autotiles = {
     },
     -- bg dirt (simplistic - only corner tiles are used)
     [3] = {
-		[0]  = 40,
-		[1]  = 40,
-		[2]  = 40,
-		[3]  = 40,
-		[4]  = 40,
-		[5]  = 58,
-		[6]  = 57,
-		[7]  = 40,
-		[8]  = 40,
-		[9]  = 42,
-		[10] = 41,
-		[11] = 40,
-		[12] = 40,
-		[13] = 40,
-		[14] = 40,
-		[15] = 40,
-		-- extra
-		[16] = 16,
-		[17] = 56,
-		[18] = 88,
-		[19] = 103,
-		[20] = 104,
-	},
+        [0]  = 40,
+        [1]  = 40,
+        [2]  = 40,
+        [3]  = 40,
+        [4]  = 40,
+        [5]  = 58,
+        [6]  = 57,
+        [7]  = 40,
+        [8]  = 40,
+        [9]  = 42,
+        [10] = 41,
+        [11] = 40,
+        [12] = 40,
+        [13] = 40,
+        [14] = 40,
+        [15] = 40,
+        -- extra
+        [16] = 16,
+        [17] = 56,
+        [18] = 88,
+        [19] = 103,
+        [20] = 104,
+    },
 }
 
 autotilet, autotilet_strict = {}, {}
@@ -111,9 +111,9 @@ function autotile(room, i, j, k)
 end
 
 function autotileWithNeighbors(room, i, j, k)
-	autotile(room, i, j, k)
-	autotile(room, i + 1, j, k)
-	autotile(room, i - 1, j, k)
-	autotile(room, i, j + 1, k)
-	autotile(room, i, j - 1, k)
+    autotile(room, i, j, k)
+    autotile(room, i + 1, j, k)
+    autotile(room, i - 1, j, k)
+    autotile(room, i, j + 1, k)
+    autotile(room, i, j - 1, k)
 end

--- a/src/keyboard.lua
+++ b/src/keyboard.lua
@@ -5,9 +5,9 @@ function love.keypressed(key, scancode, isrepeat)
     if key == "return" then
         app.enterPressed = true
     end
-    
+
     -- first handle actions that are allowed to repeat when holding key
-    
+
     local dx, dy = 0, 0
     if key == "left" then dx = -1 end
     if key == "right" then dx = 1 end
@@ -17,7 +17,7 @@ function love.keypressed(key, scancode, isrepeat)
         project.selection.x = project.selection.x + dx*8
         project.selection.y = project.selection.y + dy*8
     end
-    
+
     -- Ctrl+Z, Ctrl+Shift+Z
     if love.keyboard.isDown("lctrl") then
         if key == "z" then
@@ -28,32 +28,32 @@ function love.keypressed(key, scancode, isrepeat)
             end
         end
     end
-    
+
     -- room switching / swapping
     if key == "down" or key == "up" then
         if app.room then
             local n1 = app.room
             local n2 = key == "down" and app.room + 1 or app.room - 1
-            
+
             if project.rooms[n1] and project.rooms[n2] then
-				if love.keyboard.isDown("lctrl") then
-					-- swap
-					local tmp = project.rooms[n1]
-					project.rooms[n1] = project.rooms[n2]
-					project.rooms[n2] = tmp
-				end
-                
+                if love.keyboard.isDown("lctrl") then
+                    -- swap
+                    local tmp = project.rooms[n1]
+                    project.rooms[n1] = project.rooms[n2]
+                    project.rooms[n2] = tmp
+                end
+
                 app.room = n2
             end
         end
     end
-    
+
     if isrepeat then
         return
     end
-    
+
     -- non-repeatable global shortcuts
-    
+
     if love.keyboard.isDown("lctrl") or love.keyboard.isDown("rctrl") then
         -- Ctrl+O
         if key == "o" then
@@ -66,25 +66,25 @@ function love.keypressed(key, scancode, isrepeat)
                 elseif ext == "p8" then
                     openOk = openPico8(filename)
                 end
-                
+
                 if openOk then
-					app.history = {}
-					app.historyN = 0
-					pushHistory()
-				end
+                    app.history = {}
+                    app.historyN = 0
+                    pushHistory()
+                end
             end
             if openOk then
-				showMessage("Opened "..string.match(filename, psep.."([^"..psep.."]*)$"))
-			else
-				showMessage("Failed to open file")
-			end
-		-- Ctrl+R
+                showMessage("Opened "..string.match(filename, psep.."([^"..psep.."]*)$"))
+            else
+                showMessage("Failed to open file")
+            end
+        -- Ctrl+R
         elseif key == "r" then
-			if app.openFileName then
-				local data = loadpico8(app.openFileName)
-				p8data.spritesheet = data.spritesheet
-				showMessage("Reloaded")
-			end
+            if app.openFileName then
+                local data = loadpico8(app.openFileName)
+                p8data.spritesheet = data.spritesheet
+                showMessage("Reloaded")
+            end
         -- Ctrl+S
         elseif key == "s" then
             local filename
@@ -93,7 +93,7 @@ function love.keypressed(key, scancode, isrepeat)
             else
                 filename = filedialog.save()
             end
-            
+
             if filename and savePico8(filename) then
                 showMessage("Saved "..string.match(filename, psep.."([^"..psep.."]*)$"))
             else
@@ -108,7 +108,7 @@ function love.keypressed(key, scancode, isrepeat)
                     love.system.setClipboardText(s)
                     table.remove(project.rooms, app.room)
                     app.room = nil
-                    
+
                     showMessage("Cut room")
                 end
             else
@@ -117,7 +117,7 @@ function love.keypressed(key, scancode, isrepeat)
                     local s = dumplua {"selection", project.selection}
                     love.system.setClipboardText(s)
                     project.selection = nil
-                    
+
                     showMessage("Cut")
                 end
             end
@@ -128,7 +128,7 @@ function love.keypressed(key, scancode, isrepeat)
                 if activeRoom() then
                     local s = dumplua {"room", activeRoom()}
                     love.system.setClipboardText(s)
-                    
+
                     showMessage("Copied room")
                 end
             else
@@ -137,14 +137,14 @@ function love.keypressed(key, scancode, isrepeat)
                     local s = dumplua {"selection", project.selection}
                     love.system.setClipboardText(s)
                     placeSelection()
-                    
+
                     showMessage("Copied")
                 end
             end
         -- Ctrl+V
         elseif key == "v" then
             placeSelection() -- to clean selection first
-            
+
             local t, err = loadlua(love.system.getClipboardText())
             if not err then
                 if type(t) == "table" then
@@ -154,7 +154,7 @@ function love.keypressed(key, scancode, isrepeat)
                         project.selection.x = roundto8(mx - s.w*4)
                         project.selection.y = roundto8(my - s.h*4)
                         app.tool = "select"
-                        
+
                         showMessage("Pasted")
                     elseif t[1] == "room" then
                         local r = t[2]
@@ -177,55 +177,55 @@ function love.keypressed(key, scancode, isrepeat)
                 app.tool = "select"
                 select(0, 0, activeRoom().w - 1, activeRoom().h - 1)
             end
-		elseif key=="h" then 
-			app.showGarbageTiles=not app.showGarbageTiles
+        elseif key=="h" then
+            app.showGarbageTiles=not app.showGarbageTiles
         end
     else -- if ctrl is not down
-		if key == "delete" and love.keyboard.isDown("lshift") then
-			if app.room then
-				table.remove(project.rooms, app.room)
-				if not activeRoom() then
-					app.room = #project.rooms
-				end
-			end
+        if key == "delete" and love.keyboard.isDown("lshift") then
+            if app.room then
+                table.remove(project.rooms, app.room)
+                if not activeRoom() then
+                    app.room = #project.rooms
+                end
+            end
         end
     end
-    
+
     -- now pass to nuklear and return if consumed
-    
+
     if ui:keypressed(key, scancode, isrepeat) then
         return
     end
-    
+
     -- another fucking hack: the shit above doesnt consume inputs when editing text for some fucking reason
     if app.editCamTrigger or app.editParams then
         return
     end
-    
+
     -- now editing things (that shouldn't happen if you have a nuklear window focused or something)
-    
+
     if key == "n" then
         local room = newRoom(roundto8(mx), roundto8(my), 16, 16)
-        
+
         -- disabled that shit
         -- generate alphabetic room title
         --local n, title = 0, nil
         --while true do
-			--title = b26(n)
-			--local exists = false
-			--for _, otherRoom in ipairs(project.rooms) do
-				--if otherRoom.title == title then
-					--exists = true
-				--end
-			--end
-			--if not exists then
-				--break
-			--end
-			--n = n + 1
-		--end
-		--room.title = title
-		room.title = ""
-        
+            --title = b26(n)
+            --local exists = false
+            --for _, otherRoom in ipairs(project.rooms) do
+                --if otherRoom.title == title then
+                    --exists = true
+                --end
+            --end
+            --if not exists then
+                --break
+            --end
+            --n = n + 1
+        --end
+        --room.title = title
+        room.title = ""
+
         table.insert(project.rooms, room)
         app.room = #project.rooms
         app.roomAdded = true
@@ -235,12 +235,12 @@ function love.keypressed(key, scancode, isrepeat)
         placeSelection()
     elseif key == "tab" and not love.keyboard.isDown("lalt") then
         if not app.playtesting then
-			app.playtesting = 1
-		elseif app.playtesting == 1 then
-			app.playtesting = 2
-		else
-			app.playtesting = false
-		end
+            app.playtesting = 1
+        elseif app.playtesting == 1 then
+            app.playtesting = 2
+        else
+            app.playtesting = false
+        end
     elseif key == "delete" then
         local room=activeRoom()
         if project.selected_camtrigger and room then
@@ -260,20 +260,20 @@ function love.keypressed(key, scancode, isrepeat)
 end
 
 function love.keyreleased(key, scancode)
-	-- just save history every time a key is released lol
+    -- just save history every time a key is released lol
     pushHistory()
 
-	if ui:keyreleased(key, scancode) then
-		return
-	end
-	
-	-- this shortcut is handled on release, and can be consumed
-	-- so you don't input r into the field
+    if ui:keyreleased(key, scancode) then
+        return
+    end
+
+    -- this shortcut is handled on release, and can be consumed
+    -- so you don't input r into the field
     if key == "r" and not love.keyboard.isDown("lctrl") and activeRoom() then
         local room=activeRoom()
         app.editParams = room
         app.editParamsTable ={exits={},hex={value=room.hex}}
-        for k,v in pairs(room.exits) do 
+        for k,v in pairs(room.exits) do
             app.editParamsTable.exits[k]={value=v}
         end
     end

--- a/src/mainloop.lua
+++ b/src/mainloop.lua
@@ -3,18 +3,18 @@
 function tileButton(n, highlight)
     local x, y, w, h = ui:widgetBounds()
     ui:image({p8data.spritesheet, p8data.quads[n]})
-    
+
     local hov = false
     if ui:inputIsHovered(x, y, w, h) then
         hov = true
     end
     if hov or highlight then
-		love.graphics.setLineWidth(1)
+        love.graphics.setLineWidth(1)
         if hov then
-			love.graphics.setColor(0, 1, 0.5)
-		else
-			love.graphics.setColor(1, 1, 1)
-		end
+            love.graphics.setColor(0, 1, 0.5)
+        else
+            love.graphics.setColor(1, 1, 1)
+        end
         x, y = x - 0.5, y - 0.5
         w, h = w + 1, h + 1
         ui:line(x, y, x + w, y)
@@ -23,19 +23,19 @@ function tileButton(n, highlight)
         ui:line(x, y + h, x + w, y + h)
     end
     if ui:inputIsMousePressed("left", x, y, w, h) then
-		return true
-	end
+        return true
+    end
 end
 
 function toolLabel(label, tool)
     local hov = ui:widgetIsHovered()
     local x, y, w, h = ui:widgetBounds()
-    
+
     local color = "#afafaf"
     if tool == app.tool then
         color = "#00ff88"
     end
-    
+
     if hov then
         local bg = "#00ff88" --"#afafaf"
         ui:rectMultiColor(x, y, w + 4, h, bg, bg, bg, bg)
@@ -45,12 +45,12 @@ function toolLabel(label, tool)
                 background = bg,
             }
         }
-        
+
         app.tool = tool
     end
-    
+
     ui:label(label, "left", color)
-    
+
     if hov then ui:stylePop() end
 end
 
@@ -66,19 +66,19 @@ function love.load(args)
     love.keyboard.setKeyRepeat(true)
 
     ui = nuklear.newUI()
-    
+
     global_scale=1 -- global scale, to run nicely on hi dpi displays
     tms = 4 -- tile menu scale
 
     for _,v in ipairs(args) do
-        if v=="--hidpi" then 
+        if v=="--hidpi" then
             global_scale = 2
             tms = 4*global_scale
         end
     end
 
     --p8data = loadpico8(love.filesystem.getSource().."\\celeste.p8")
-    
+
     newProject()
     pushHistory()
 
@@ -87,7 +87,7 @@ function love.load(args)
     checkmarkIm=love.graphics.newImage("checkmark.png")
     checkmarkWithBg=love.graphics.newCanvas(checkmarkIm:getWidth()*5/4,checkmarkIm:getHeight()*5/4)
     love.graphics.setCanvas(checkmarkWithBg)
-    love.graphics.clear(0x64/0xff,0x64/0xff,0x64/0xff) 
+    love.graphics.clear(0x64/0xff,0x64/0xff,0x64/0xff)
     love.graphics.draw(checkmarkIm,checkmarkIm:getWidth()/8,checkmarkIm:getHeight()/8)
     love.graphics.setCanvas()
 end
@@ -98,24 +98,24 @@ function love.update(dt)
     app.left, app.top = rpw, 0
 
     ui:frameBegin()
-		--ui:scale(2)
+        --ui:scale(2)
     ui:stylePush {
         window = {
             spacing = {x = 1, y = 1},
             padding = {x = 1, y = 1},
         },
         selectable = {
-			padding = {x = 0, y = 0},
-			["normal active"] = "#000000",
-			["hover active"] = "#000000",
-			["pressed active"] = "#000000",
-		},
+            padding = {x = 0, y = 0},
+            ["normal active"] = "#000000",
+            ["hover active"] = "#000000",
+            ["pressed active"] = "#000000",
+        },
         checkbox = {
             ["cursor normal"] = checkmarkIm,
             ["cursor hover"] = checkmarkIm
         }
     }
-    
+
     -- room panel
     if ui:windowBegin("Room Panel", 0, 0, rpw, app.H, {"scrollbar"}) then
         ui:layoutRow("dynamic", 25*global_scale, 1)
@@ -124,61 +124,70 @@ function love.update(dt)
                 app.room = n
             end
         end
-        
+
         if app.roomAdded then
-			ui:windowSetScroll(0, 100000)
-			app.roomAdded = false
-		end
+            ui:windowSetScroll(0, 100000)
+            app.roomAdded = false
+        end
     end
     ui:windowEnd()
-    
+
     -- tool panel
     if app.showToolPanel then
-		local tpw = 16*8*tms + 18
-		if ui:windowBegin("Tool panel", app.W - tpw, 0, tpw, app.H) then
-			ui:layoutRow("static", 25*global_scale, 100*global_scale, 2)
-			if ui:selectable("Brush", app.tool == "brush") then app.tool = "brush" end
-			if ui:selectable("Rectangle", app.tool == "rectangle") then app.tool = "rectangle" end
-			ui:layoutRow("static", 25*global_scale, 100*global_scale, 1)
-			if ui:selectable("Select", app.tool == "select") then app.tool = "select" end
-			ui:layoutRow("static", 25*global_scale, 100*global_scale, 1)
-			if ui:selectable("Camera Trigger", app.tool == "camtrigger") then app.tool = "camtrigger" end
-			
-			for j = 0, app.showGarbageTiles and 15 or 7 do
-				ui:layoutRow("static", 8*tms, 8*tms, 16)
-				for i = 0, 15 do
-					local n = i + j*16
-					if tileButton(n, app.currentTile == n and not app.autotile) then
-						app.currentTile = n
-						app.autotile = nil
-					end
-				end
-			end
-			
-			ui:layoutRow("dynamic", 25*global_scale, 1)
+        local tpw = 16*8*tms + 18
+        if ui:windowBegin("Tool panel", app.W - tpw, 0, tpw, app.H) then
+            -- tools list
+            for row = 0, math.ceil(#toolslist/4) - 1 do
+                ui:layoutRow("dynamic", 25*global_scale, 4)
+
+                for i = 0, 3 do
+                    local tool = toolslist[1 + row*4+i]
+
+                    if ui:selectable(tools[tool].name, app.tool == tool) then
+                        app.tool = tool
+                    end
+                end
+            end
+
+            -- tiles
+            ui:layoutRow("dynamic", 25*global_scale, 1)
+            ui:label("Tiles:")
+            for j = 0, app.showGarbageTiles and 15 or 7 do
+                ui:layoutRow("static", 8*tms, 8*tms, 16)
+                for i = 0, 15 do
+                    local n = i + j*16
+                    if tileButton(n, app.currentTile == n and not app.autotile) then
+                        app.currentTile = n
+                        app.autotile = nil
+                    end
+                end
+            end
+
+            -- autotiles
+            ui:layoutRow("dynamic", 25*global_scale, 1)
             ui:label("Autotiles:")
             ui:layoutRow("static", 8*tms, 8*tms, #autotiles)
-			for k, auto in ipairs(autotiles) do
-				if tileButton(auto[5], app.currentTile == auto[15] and app.autotile) then
-					app.currentTile = auto[15]
-					app.autotile = k
-				end
-			end
-		end
-		ui:windowEnd()
-	end
-    
+            for k, auto in ipairs(autotiles) do
+                if tileButton(auto[5], app.currentTile == auto[15] and app.autotile) then
+                    app.currentTile = auto[15]
+                    app.autotile = k
+                end
+            end
+        end
+        ui:windowEnd()
+    end
+
     --if app.renameRoom then
         --local room = app.renameRoom
-        
+
         --local w, h = 200*global_scale, 88*global_scale
         --if ui:windowBegin("Rename room", app.W/2 - w/2, app.H/2 - h/2, w, h, {"title", "border", "closable", "movable"}) then
             --ui:layoutRow("dynamic", 25*global_scale, 1)
-            
+
             --local state, changed
             --ui:editFocus()
             --state, changed = ui:edit("simple", app.renameRoomVTable)
-            
+
             --if ui:button("OK") or app.enterPressed then
                 --room.title = app.renameRoomVTable.value
                 --app.renameRoom = nil
@@ -190,7 +199,7 @@ function love.update(dt)
     --end
     if app.editParams then
         local room = app.editParams
-        
+
         local w, h = 500*global_scale, 125*global_scale
         if ui:windowBegin("Edit Room Parameters", app.W/2 - w/2, app.H/2 - h/2, w, h, {"title", "border", "closable", "movable"}) then
 
@@ -201,32 +210,32 @@ function love.update(dt)
                 local style={}
                 for k,v in pairs({"text normal", "text hover", "text active"}) do
                     style[v]="#707070"
-                end 
+                end
                 for k,v in pairs({"normal", "hover", "active"}) do
                     style[v]=checkmarkWithBg -- show both selected and unselected as having a check to avoid nukelear limitations
                     -- kinda hacky but it works decently enough
-                end 
+                end
                 ui:stylePush({['checkbox']=style})
 
             else
                 ui:stylePush({})
-            end 
+            end
             ui:checkbox("Level Stored As Hex",fits_on_map and app.editParamsTable.hex or true)
             ui:stylePop()
 
 
             ui:layoutRow("dynamic", 25*global_scale, 5)
             ui:label("Level Exits:")
-            for _,v in pairs({"left","bottom","right","top"}) do 
+            for _,v in pairs({"left","bottom","right","top"}) do
                 ui:checkbox(v,app.editParamsTable.exits[v])
-            end 
+            end
             --ui:checkbox("test",app.editParamsVTable.test)
             ui:layoutRow("dynamic",25*global_scale,1)
             if ui:button("OK") or app.enterPressed then
                 --room.params.test=app.editParamsVTable.test.value
                 --print(room.params.test)
                 app.editParams.hex=app.editParamsTable.hex.value
-                for k,v in pairs(app.editParamsTable.exits) do 
+                for k,v in pairs(app.editParamsTable.exits) do
                     app.editParams.exits[k]=v.value
                 end
                 app.editParams = nil
@@ -238,14 +247,14 @@ function love.update(dt)
     end
     if app.editCamtrigger then
         local room = app.editParams
-        
+
         local w, h = 400*global_scale, 88*global_scale
         if ui:windowBegin("Edit Camera Triggers", app.W/2 - w/2, app.H/2 - h/2, w, h, {"title", "border", "closable", "movable"}) then
             ui:layoutRow("dynamic",25*global_scale,4)
             ui:label("x offset","centered")
-            ui:edit("simple",app.editCamtriggerTable.x) 
+            ui:edit("simple",app.editCamtriggerTable.x)
             ui:label("y offset","centered")
-            ui:edit("simple",app.editCamtriggerTable.y) 
+            ui:edit("simple",app.editCamtriggerTable.y)
             ui:layoutRow("dynamic",25*global_scale,1)
             if ui:button("OK") or app.enterPressed then
                 --room.params.test=app.editParamsVTable.test.value
@@ -259,60 +268,43 @@ function love.update(dt)
         end
         ui:windowEnd()
     end
-    
+
     app.enterPressed = false
-    
+
     app.anyWindowHovered = ui:windowIsAnyHovered()
-    
+
     ui:stylePop()
-    
-    local hov = ui:windowIsAnyHovered()
-    
+
+    -- tool update
+    if tools[app.tool] and tools[app.tool].update then
+        tools[app.tool].update(dt)
+    end
+
     ui:frameEnd()
 
-    if app.brushing and not hov and not love.keyboard.isDown("lalt") and (love.mouse.isDown(1) or love.mouse.isDown(2)) then
-        if app.tool == "brush" then
-            local n = app.currentTile
-            if love.mouse.isDown(2) then
-                n = 0
-            end
-            
-            local ti, tj = mouseOverTile()
-            if ti then
-                local room = activeRoom()
-                
-                activeRoom().data[ti][tj] = n
-                
-                if app.autotile then
-                    autotileWithNeighbors(activeRoom(), ti, tj, app.autotile)
-                end
-            end
-        end
-    end
-    
     local x, y = love.mouse.getPosition()
     local mx, my = fromScreen(x, y)
-    
+
     if app.roomResizeSideX and app.room then
         local room = activeRoom()
-        
+
         local left, top = room.x, room.y
         local right, bottom = left + room.w*8, top + room.h*8
-        
+
         local ax = app.roomResizeSideX > 0 and right or left
         local ay = app.roomResizeSideY > 0 and bottom or top
-        
+
         local dx = div8(math.abs(mx-ax)) * sign(mx-ax) * app.roomResizeSideX
         local dy = div8(math.abs(my-ay)) * sign(my-ay) * app.roomResizeSideY
-        
+
         if dx ~= 0 or dy ~= 0 then
             local newdata, neww, newh = {}, math.max(1, room.w + dx), math.max(1, room.h + dy)
-            
+
             -- copy all tiles (even if outside bounds - so they persist if you cut part of room off and then resize back)
             for i, col in pairs(room.data) do
                 for j, n in pairs(col) do
                     local i_, j_ = i + (ax == left and dx or 0), j + (ay == top and dy or 0)
-                    
+
                     if not newdata[i_] then newdata[i_] = {} end
                     newdata[i_][j_] = n
                 end
@@ -324,17 +316,17 @@ function love.update(dt)
                     newdata[i][j] = newdata[i][j] or 0
                 end
             end
-            
+
             room.x = room.x - (ax == left and 8*(neww-room.w) or 0)
             room.y = room.y - (ay == top and 8*(newh-room.h) or 0)
             room.data, room.w, room.h = newdata, neww, newh
         end
     end
-    
+
     if project.selection and app.tool ~= "select" then
         placeSelection()
     end
-    
+
     if app.message then
         app.messageTimeLeft = app.messageTimeLeft - dt
         if app.messageTimeLeft < 0 then
@@ -348,14 +340,14 @@ function love.draw()
     love.graphics.clear(0.25, 0.25, 0.25)
     love.graphics.reset()
     love.graphics.setLineStyle("rough")
-    
+
     local x, y = love.mouse.getPosition()
     local mx, my = fromScreen(x, y)
-    
+
     local ox, oy = toScreen(0, 0)
     love.graphics.translate(math.floor(ox), math.floor(oy))
     love.graphics.scale(app.camScale)
-    
+
     love.graphics.setColor(0.28, 0.28, 0.28)
     love.graphics.setLineWidth(2)
     for i = 0, 7 do
@@ -363,10 +355,10 @@ function love.draw()
             love.graphics.rectangle("line", i*128, j*128, 128, 128)
         end
     end
-    
+
     for _, room in ipairs(project.rooms) do
-		if room ~= activeRoom() then
-			drawRoom(room, p8data)
+        if room ~= activeRoom() then
+            drawRoom(room, p8data)
             love.graphics.setColor(0.5, 0.5, 0.5, 0.4)
             love.graphics.rectangle("fill", room.x, room.y, room.w*8, room.h*8)
         end
@@ -380,44 +372,21 @@ function love.draw()
         love.graphics.setLineWidth(1 / app.camScale)
         love.graphics.rectangle("line", project.selection.x + 0.5 / app.camScale, project.selection.y + 0.5 / app.camScale, project.selection.w*8, project.selection.h*8)
     end
-    
-    local ti, tj = mouseOverTile()
-    
-    if app.tool == "brush" or (app.tool == "rectangle" and not app.rectangleI) then
-        if ti and not app.toolMenuX then
-            love.graphics.setColor(1, 1, 1)
-            love.graphics.draw(p8data.spritesheet, p8data.quads[app.currentTile], activeRoom().x + ti*8, activeRoom().y + tj*8)
-            
-            love.graphics.setColor(0, 1, 0.5)
-            love.graphics.setLineWidth(1 / app.camScale)
-            love.graphics.rectangle("line", activeRoom().x + ti*8 + 0.5 / app.camScale, 
-                                            activeRoom().y + tj*8 + 0.5 / app.camScale, 8, 8)
-        end
-    elseif (app.tool == "rectangle" and app.rectangleI) or app.tool == "select" or app.tool=="camtrigger" then
-        local i1, j1 = app.rectangleI or app.selectTileI or app.camtriggerI, app.rectangleJ or app.selectTileJ or app.camtriggerJ
-        if i1 and ti then
-            local i, j, w, h = rectCont2Tiles(ti, tj, i1, j1)
-            if app.tool=="camtrigger" then
-                love.graphics.setColor(1,0.75,0)
-            else
-                love.graphics.setColor(0, 1, 0.5)
-            end
-            love.graphics.setLineWidth(1 / app.camScale)
-            love.graphics.rectangle("line", activeRoom().x + i*8 + 0.5 / app.camScale, 
-                                            activeRoom().y + j*8 + 0.5 / app.camScale,
-                                            w*8, h*8)
-        end
+
+    -- tool draw
+    if tools[app.tool] and tools[app.tool].draw then
+        tools[app.tool].draw()
     end
-    
+
     love.graphics.reset()
     love.graphics.setColor(1, 1, 1)
     love.graphics.translate(app.left, app.top)
     love.graphics.setFont(app.font)
-		
+
     if app.message then
         love.graphics.print(app.message, 4, app.H - app.font:getHeight() - 4)
     end
-    
+
     if app.playtesting then
         local s = app.playtesting == 1 and "[playtesting]" or "[playtesting, 2 dashes]"
         love.graphics.print(s, 4, 4)

--- a/src/mainloop.lua
+++ b/src/mainloop.lua
@@ -145,7 +145,17 @@ function love.update(dt)
                     local tool = toolslist[1 + row*4+i]
 
                     if ui:selectable(tools[tool].name, app.tool == tool) then
-                        app.tool = tool
+                        if app.tool and app.tool ~= tool then
+                            if tools[app.tool].ondisabled then
+                                tools[app.tool].ondisabled()
+                            end
+
+                            app.tool = tool
+
+                            if tools[app.tool].onenabled then
+                                tools[app.tool].onenabled()
+                            end
+                        end
                     end
                 end
             end
@@ -322,14 +332,6 @@ function love.update(dt)
             room.y = room.y - (ay == top and 8*(newh-room.h) or 0)
             room.data, room.w, room.h = newdata, neww, newh
         end
-    end
-
-    if project.selection and app.tool ~= "select" then
-        placeSelection()
-    end
-
-    if app.tool ~= "camtrigger" then
-        project.selected_camtrigger = nil
     end
 
     if app.message then

--- a/src/mainloop.lua
+++ b/src/mainloop.lua
@@ -146,15 +146,11 @@ function love.update(dt)
 
                     if ui:selectable(tools[tool].name, app.tool == tool) then
                         if app.tool and app.tool ~= tool then
-                            if tools[app.tool].ondisabled then
-                                tools[app.tool].ondisabled()
-                            end
+                            tools[app.tool].ondisabled()
 
                             app.tool = tool
 
-                            if tools[app.tool].onenabled then
-                                tools[app.tool].onenabled()
-                            end
+                            tools[app.tool].onenabled()
                         end
                     end
                 end
@@ -287,9 +283,7 @@ function love.update(dt)
     ui:stylePop()
 
     -- tool update
-    if tools[app.tool] and tools[app.tool].update then
-        tools[app.tool].update(dt)
-    end
+    tools[app.tool].update(dt)
 
     ui:frameEnd()
 
@@ -381,9 +375,7 @@ function love.draw()
     end
 
     -- tool draw
-    if tools[app.tool] and tools[app.tool].draw then
-        tools[app.tool].draw()
-    end
+    tools[app.tool].draw()
 
     love.graphics.reset()
     love.graphics.setColor(1, 1, 1)

--- a/src/mainloop.lua
+++ b/src/mainloop.lua
@@ -144,13 +144,15 @@ function love.update(dt)
                 for i = 0, 3 do
                     local tool = toolslist[1 + row*4+i]
 
-                    if ui:selectable(tools[tool].name, app.tool == tool) then
-                        if app.tool and app.tool ~= tool then
-                            tools[app.tool].ondisabled()
+                    if tool then
+                        if ui:selectable(tools[tool].name, app.tool == tool) then
+                            if app.tool and app.tool ~= tool then
+                                tools[app.tool].ondisabled()
 
-                            app.tool = tool
+                                app.tool = tool
 
-                            tools[app.tool].onenabled()
+                                tools[app.tool].onenabled()
+                            end
                         end
                     end
                 end

--- a/src/mouse.lua
+++ b/src/mouse.lua
@@ -1,153 +1,62 @@
 function love.mousepressed(x, y, button, istouch, presses)
     if ui:mousepressed(x, y, button, istouch, presses) then
-	return
+        return
     end
 
     local mx, my = fromScreen(x, y)
     if button == 1 then
-	if not app.toolMenuX then
-	    local oldActiveRoom = app.room
-	    for i, room in ipairs(project.rooms) do
-		if mx >= room.x and mx <= room.x + room.w*8
-		    and my >= room.y and my <= room.y + room.h*8 then
-		    app.room = i
-		    if app.room == oldActiveRoom then
-			break
-		    end
-		end
-	    end
-	    if app.room ~= oldActiveRoom then
-		app.suppressMouse = true
-	    end
+        if not app.toolMenuX then
+            local oldActiveRoom = app.room
+            for i, room in ipairs(project.rooms) do
+                if mx >= room.x and mx <= room.x + room.w*8
+                and my >= room.y and my <= room.y + room.h*8 then
+                    app.room = i
+                    if app.room == oldActiveRoom then
+                        break
+                    end
+                end
+            end
+            if app.room ~= oldActiveRoom then
+                app.suppressMouse = true
+            end
 
-	    if love.keyboard.isDown("lalt") then
-		if app.room then
-		    app.roomMoveX, app.roomMoveY = mx - activeRoom().x, my - activeRoom().y
-		end
-		return
-	    end
-
-	    if app.tool == "brush" and not app.suppressMouse then
-		app.brushing = true
-	    elseif app.tool == "select" then
-		local ti, tj = mouseOverTile()
-		if not project.selection then
-		    if ti then
-			app.selectTileI, app.selectTileJ = ti, tj
-		    end
-		else
-		    project.selectionMoveX, project.selectionMoveY = mx - project.selection.x, my - project.selection.y
-		    project.selectionStartX, project.selectionStartY = project.selection.x, project.selection.y
-		end
-	    end
-	end
+            if love.keyboard.isDown("lalt") then
+                if app.room then
+                    app.roomMoveX, app.roomMoveY = mx - activeRoom().x, my - activeRoom().y
+                end
+                return
+            end
+        end
     elseif button == 2 then
-	if love.keyboard.isDown("lalt") and app.room then
-	    app.roomResizeSideX = sign(mx - activeRoom().x - activeRoom().w*8/2)
-	    app.roomResizeSideY = sign(my - activeRoom().y - activeRoom().h*8/2)
-	    return
-	end
-
-	if app.tool == "brush" then
-	    app.brushing = true
-	end
-    elseif button == 3 then
-	app.camMoveX, app.camMoveY = fromScreen(x, y)
+        if love.keyboard.isDown("lalt") and app.room then
+            app.roomResizeSideX = sign(mx - activeRoom().x - activeRoom().w*8/2)
+            app.roomResizeSideY = sign(my - activeRoom().y - activeRoom().h*8/2)
+            return
+        end
     end
 
-    if button == 1 or button == 2 then
-		local ti, tj = mouseOverTile()
-		if app.tool == "rectangle" and ti then
-			app.rectangleI, app.rectangleJ = ti, tj
-		end
-		if app.tool == "camtrigger" and ti then
-			local hovered=hoveredTrigger()
-			if project.selected_camtrigger then
-				project.selected_camtrigger=false
-				--rn deselect
-				-- TODO: implement resizing and moving (like rooms)
-			elseif hovered then 
-				project.selected_camtrigger=hovered
-			else
-				app.camtriggerI, app.camtriggerJ = ti, tj
-			end
-		end
+    if button == 3 then
+        app.camMoveX, app.camMoveY = fromScreen(x, y)
+    end
+
+    --tool mousepressed
+    if tools[app.tool] and tools[app.tool].mousepressed then
+        tools[app.tool].mousepressed(x, y, button)
     end
 end
 
 function love.mousereleased(x, y, button, istouch, presses)
-    if ui:mousereleased(x, y, button, istouch, presses) then
-	return
-    end
+    ui:mousereleased(x, y, button, istouch, presses)
+    -- note: mousereleased is not swallowed by nuklear windows, unlike mousepressed
 
-    local ti, tj = mouseOverTile()
-
-    if app.tool == "rectangle" or app.tool == "select" then
-	local i1, j1 = app.rectangleI or app.selectTileI, app.rectangleJ or app.selectTileJ
-
-	if app.tool == "rectangle" and i1 and ti then
-	    local room = activeRoom()
-
-	    local n = app.currentTile
-	    if app.autotile then
-		n = autotiles[autotilet[n]][15] -- inner version
-	    end
-	    if button == 2 then
-		n = 0
-	    end
-
-	    local i0, j0, w, h = rectCont2Tiles(i1, j1, ti, tj)
-	    for i = i0, i0 + w - 1 do
-		for j = j0, j0 + h - 1 do
-		    room.data[i][j] = n
-		end
-	    end
-
-	    if app.autotile then
-		for i = i0, i0 + w - 1 do
-		    autotileWithNeighbors(room, i, j0)
-		    autotileWithNeighbors(room, i, j0 + h - 1)
-		end
-		for j = j0 + 1, j0 + h - 2 do
-		    autotileWithNeighbors(room, i0, j)
-		    autotileWithNeighbors(room, i0 + w - 1, j)
-		end
-	    end
-	elseif app.tool == "select" then
-	    if i1 and ti then
-		placeSelection()
-
-		select(ti, tj, i1, j1)
-	    end
-
-	    if project.selection and project.selectionMoveX then
-		if project.selection.x == project.selectionStartX and project.selection.y == project.selectionStartY then
-		    placeSelection()
-		end
-	    end
-	end
-	elseif app.tool == "camtrigger" then
-		local i1, j1 = app.camtriggerI, app.camtriggerJ
-		local room = activeRoom()
-		if i1 and ti then
-			local room = activeRoom()
-			local i0, j0, w, h = rectCont2Tiles(i1, j1, ti, tj)
-			local trigger={x=i0,y=j0,w=w,h=h,off_x=0,off_y=0}
-			table.insert(room.camtriggers,trigger)
-			app.editCamtrigger=trigger
-			app.editCamtriggerTable={x={value=0},y={value=0}}
-			project.selected_camtrigger=trigger
-		end 
+    --tool mousereleased
+    if tools[app.tool] and tools[app.tool].mousereleased then
+        tools[app.tool].mousereleased(x, y, button)
     end
 
     app.camMoveX, app.camMoveY = nil, nil
     app.roomMoveX, app.roomMoveY = nil, nil
     app.roomResizeSideX, app.roomResizeSideY = nil, nil
-    app.brushing = false
-    app.rectangleI, app.rectangleJ = nil, nil
-    app.selectTileI, app.selectTileJ = nil, nil
-    app.camtriggerI, app.camtriggerJ = nil, nil
-    project.selectionMoveX, project.selectionMoveY = nil, nil
 
     app.suppressMouse = false
 
@@ -157,47 +66,52 @@ end
 
 function love.mousemoved(x, y, dx, dy, istouch)
     if ui:mousemoved(x, y, dx, dy, istouch) then
-	return
+        return
     end
 
     local mx, my = fromScreen(x, y)
     local ti, tj = div8(mx), div8(my)
     if app.camMoveX then
-	app.camX = app.camX + mx - app.camMoveX
-	app.camY = app.camY + my - app.camMoveY
+        app.camX = app.camX + mx - app.camMoveX
+        app.camY = app.camY + my - app.camMoveY
     end
     if app.roomMoveX and app.room then
-	activeRoom().x = roundto8(mx - app.roomMoveX)
-	activeRoom().y = roundto8(my - app.roomMoveY)
+        activeRoom().x = roundto8(mx - app.roomMoveX)
+        activeRoom().y = roundto8(my - app.roomMoveY)
     end
     if project.selectionMoveX and project.selection then
-	project.selection.x = roundto8(mx - project.selectionMoveX)
-	project.selection.y = roundto8(my - project.selectionMoveY)
+        project.selection.x = roundto8(mx - project.selectionMoveX)
+        project.selection.y = roundto8(my - project.selectionMoveY)
+    end
+
+    --tool mousemoved
+    if tools[app.tool] and tools[app.tool].mousemoved then
+        tools[app.tool].mousemoved(x, y, dx, dy)
     end
 end
 
 function love.wheelmoved(x, y)
     -- this is an inelegant solution to the fact that some slut decided that scrollbars scroll even if the window isn't even hovered
     if app.anyWindowHovered then
-	if ui:wheelmoved(x, y) then
-	    return
-	end
+        if ui:wheelmoved(x, y) then
+            return
+        end
     end
 
     if y ~= 0 then
-	local mx, my = love.mouse.getPosition()
-	rmx, rmy = fromScreen(mx, my)
+        local mx, my = love.mouse.getPosition()
+        rmx, rmy = fromScreen(mx, my)
 
-	if y > 0 then
-	    app.camScaleSetting = app.camScaleSetting + 1
-	elseif y < 0 then
-	    app.camScaleSetting = app.camScaleSetting - 1
-	end
-	app.camScaleSetting = math.min(math.max(app.camScaleSetting, -3), 20)
-	app.camScale = app.camScaleSetting > 0 and (app.camScaleSetting + 1) or 2 ^ app.camScaleSetting
+        if y > 0 then
+            app.camScaleSetting = app.camScaleSetting + 1
+        elseif y < 0 then
+            app.camScaleSetting = app.camScaleSetting - 1
+        end
+        app.camScaleSetting = math.min(math.max(app.camScaleSetting, -3), 20)
+        app.camScale = app.camScaleSetting > 0 and (app.camScaleSetting + 1) or 2 ^ app.camScaleSetting
 
-	nrmx, nrmy = fromScreen(mx, my)
-	app.camX = app.camX + nrmx - rmx
-	app.camY = app.camY + nrmy - rmy
+        nrmx, nrmy = fromScreen(mx, my)
+        app.camX = app.camX + nrmx - rmx
+        app.camY = app.camY + nrmy - rmy
     end
 end

--- a/src/mouse.lua
+++ b/src/mouse.lua
@@ -40,9 +40,7 @@ function love.mousepressed(x, y, button, istouch, presses)
     end
 
     --tool mousepressed
-    if tools[app.tool] and tools[app.tool].mousepressed then
-        tools[app.tool].mousepressed(x, y, button)
-    end
+    tools[app.tool].mousepressed(x, y, button)
 end
 
 function love.mousereleased(x, y, button, istouch, presses)
@@ -50,9 +48,7 @@ function love.mousereleased(x, y, button, istouch, presses)
     -- note: mousereleased is not swallowed by nuklear windows, unlike mousepressed
 
     --tool mousereleased
-    if tools[app.tool] and tools[app.tool].mousereleased then
-        tools[app.tool].mousereleased(x, y, button)
-    end
+    tools[app.tool].mousereleased(x, y, button)
 
     app.camMoveX, app.camMoveY = nil, nil
     app.roomMoveX, app.roomMoveY = nil, nil
@@ -85,9 +81,7 @@ function love.mousemoved(x, y, dx, dy, istouch)
     end
 
     --tool mousemoved
-    if tools[app.tool] and tools[app.tool].mousemoved then
-        tools[app.tool].mousemoved(x, y, dx, dy)
-    end
+    tools[app.tool].mousemoved(x, y, dx, dy)
 end
 
 function love.wheelmoved(x, y)

--- a/src/room.lua
+++ b/src/room.lua
@@ -12,7 +12,7 @@ function newRoom(x, y, w, h)
         camtriggers={}
     }
     room.data = fill2d0s(room.w, room.h)
-    
+
     return room
 end
 
@@ -25,27 +25,28 @@ function drawRoom(room, p8data, highlight)
             if not highlight or n~=0 then
                 love.graphics.setColor(1, 1, 1)
                 love.graphics.draw(p8data.spritesheet, p8data.quads[n], room.x + i*8, room.y + j*8)
-                
-                if highlight then
-                    love.graphics.setColor(0, 1, 0.5, 0.5)
-                    love.graphics.rectangle("fill", room.x + i*8, room.y + j*8, 8, 8)
-                end
+
+
             end
         end
     end
+
+    if highlight then
+        drawColoredRect(room, 0, 0, room.w*8, room.h*8, {0, 1, 0.5}, true)
+    end
+
     local highlighted = project.selected_camtrigger or hoveredTrigger()
     --TODO: draw selected and hovered in different colors maybe
     for _,trigger in ipairs(room.camtriggers) do
-		local ti, tj = mouseOverTile()
-        if trigger== highlighted then
-            love.graphics.setColor(1,0.9,0,0.5)
+        local ti, tj = mouseOverTile()
+
+        local col
+        if trigger == highlighted then
+            col = {1,0.9,0}
         else
-            love.graphics.setColor(1,0.75,0,0.5)
+            col = {1,0.75,0}
         end
-        local px,py,pw,ph=trigger.x*8+room.x,trigger.y*8+room.y,trigger.w*8,trigger.h*8
-        love.graphics.rectangle("fill",px,py,pw,ph)
-        love.graphics.setLineWidth(1 / app.camScale)
-        love.graphics.setColor(1,0.75,0)
-        love.graphics.rectangle("line",px+0.5/app.camScale,py+0.5/app.camScale,pw,ph)
+
+        drawColoredRect(room, trigger.x*8, trigger.y*8, trigger.w*8, trigger.h*8, col, true)
     end
 end

--- a/src/room.lua
+++ b/src/room.lua
@@ -25,8 +25,6 @@ function drawRoom(room, p8data, highlight)
             if not highlight or n~=0 then
                 love.graphics.setColor(1, 1, 1)
                 love.graphics.draw(p8data.spritesheet, p8data.quads[n], room.x + i*8, room.y + j*8)
-
-
             end
         end
     end

--- a/src/tools.lua
+++ b/src/tools.lua
@@ -1,0 +1,194 @@
+tools = {}
+
+-- this defines the order of tools on the panel
+toolslist = {"brush", "rectangle", "select", "camtrigger"}
+
+
+
+tools.brush = {}
+tools.brush.name = "Brush"
+
+function tools.brush.update(dt)
+    if not ui:windowIsAnyHovered() and not love.keyboard.isDown("lalt") and (love.mouse.isDown(1) or love.mouse.isDown(2)) then
+        local n = app.currentTile
+        if love.mouse.isDown(2) then
+            n = 0
+        end
+
+        local ti, tj = mouseOverTile()
+        if ti then
+            local room = activeRoom()
+
+            activeRoom().data[ti][tj] = n
+
+            if app.autotile then
+                autotileWithNeighbors(activeRoom(), ti, tj, app.autotile)
+            end
+        end
+    end
+end
+
+function tools.brush.draw()
+    drawMouseOverTile()
+end
+
+
+
+tools.rectangle = {}
+tools.rectangle.name = "Rectangle"
+
+function tools.rectangle.draw()
+    local ti, tj = mouseOverTile()
+
+    if not app.rectangleI then
+        drawMouseOverTile()
+    elseif ti then
+        local i, j, w, h = rectCont2Tiles(ti, tj, app.rectangleI, app.rectangleJ)
+        drawColoredRect(activeRoom(), i*8, j*8, w*8, h*8, {0, 1, 0.5}, false)
+    end
+end
+
+function tools.rectangle.mousepressed(x, y, button)
+    local ti, tj = mouseOverTile()
+
+    if button == 1 or button == 2 then
+        if ti then
+            app.rectangleI, app.rectangleJ = ti, tj
+        end
+    end
+end
+
+function tools.rectangle.mousereleased(x, y, button)
+    local ti, tj = mouseOverTile()
+
+    if ti and app.rectangleI then
+        local room = activeRoom()
+
+        local n = app.currentTile
+        if button == 2 then
+            n = 0
+        end
+
+        local i0, j0, w, h = rectCont2Tiles(app.rectangleI, app.rectangleJ, ti, tj)
+        for i = i0, i0 + w - 1 do
+            for j = j0, j0 + h - 1 do
+                room.data[i][j] = n
+            end
+        end
+
+        if app.autotile then
+            for i = i0, i0 + w - 1 do
+                autotileWithNeighbors(room, i, j0, app.autotile)
+                autotileWithNeighbors(room, i, j0 + h - 1, app.autotile)
+            end
+            for j = j0 + 1, j0 + h - 2 do
+                autotileWithNeighbors(room, i0, j, app.autotile)
+                autotileWithNeighbors(room, i0 + w - 1, j, app.autotile)
+            end
+        end
+    end
+
+    app.rectangleI, app.rectangleJ = nil, nil
+end
+
+
+
+tools.select = {}
+tools.select.name = "Selection"
+
+function tools.select.draw()
+    local ti, tj = mouseOverTile()
+
+    if not app.selectTileI then
+        drawMouseOverTile()
+    elseif ti then
+        local i, j, w, h = rectCont2Tiles(ti, tj, app.selectTileI, app.selectTileJ)
+        drawColoredRect(activeRoom(), i*8, j*8, w*8, h*8, {0, 1, 0.5}, false)
+    end
+end
+
+function tools.select.mousepressed(x, y, button)
+    local ti, tj = mouseOverTile()
+    local mx, my = fromScreen(x, y)
+
+    if button == 1 then
+        if not project.selection then
+            if ti then
+                app.selectTileI, app.selectTileJ = ti, tj
+            end
+        else
+            project.selectionMoveX, project.selectionMoveY = mx - project.selection.x, my - project.selection.y
+            project.selectionStartX, project.selectionStartY = project.selection.x, project.selection.y
+        end
+    end
+end
+
+function tools.select.mousereleased(x, y, button)
+    local ti, tj = mouseOverTile()
+
+    if ti and app.selectTileI then
+        placeSelection()
+
+        select(ti, tj, app.selectTileI, app.selectTileJ)
+    end
+
+    if project.selection and project.selectionMoveX then
+        if project.selection.x == project.selectionStartX and project.selection.y == project.selectionStartY then
+            placeSelection()
+        end
+    end
+
+    app.selectTileI, app.selectTileJ = nil, nil
+    project.selectionMoveX, project.selectionMoveY = nil, nil
+end
+
+
+
+tools.camtrigger = {}
+tools.camtrigger.name = "Camtrigger"
+
+function tools.camtrigger.draw()
+    local ti, tj = mouseOverTile()
+
+    if not app.camtriggerI then
+        drawMouseOverTile({1,0.75,0})
+    elseif ti then
+        local i, j, w, h = rectCont2Tiles(ti, tj, app.camtriggerI, app.camtriggerJ)
+        drawColoredRect(activeRoom(), i*8, j*8, w*8, h*8, {1,0.75,0}, false)
+    end
+end
+
+function tools.camtrigger.mousepressed(x, y, button)
+    local ti, tj = mouseOverTile()
+
+    if button == 1 then
+        if ti then
+            local hovered=hoveredTrigger()
+            if project.selected_camtrigger then
+                project.selected_camtrigger=false
+                --rn deselect
+                -- TODO: implement resizing and moving (like rooms)
+            elseif hovered then
+                project.selected_camtrigger=hovered
+            else
+                app.camtriggerI, app.camtriggerJ = ti, tj
+            end
+        end
+    end
+end
+
+function tools.camtrigger.mousereleased(x, y, button)
+    local ti, tj = mouseOverTile()
+
+    if ti and app.camtriggerI then
+        local room = activeRoom()
+        local i0, j0, w, h = rectCont2Tiles(app.camtriggerI, app.camtriggerJ, ti, tj)
+        local trigger={x=i0,y=j0,w=w,h=h,off_x=0,off_y=0}
+        table.insert(room.camtriggers,trigger)
+        app.editCamtrigger=trigger
+        app.editCamtriggerTable={x={value=0},y={value=0}}
+        project.selected_camtrigger=trigger
+    end
+
+    app.camtriggerI, app.camtriggerJ = nil, nil
+end

--- a/src/tools.lua
+++ b/src/tools.lua
@@ -96,6 +96,12 @@ end
 tools.select = {}
 tools.select.name = "Selection"
 
+function tools.select.ondisabled()
+    if project.selection then
+        placeSelection()
+    end
+end
+
 function tools.select.draw()
     local ti, tj = mouseOverTile()
 
@@ -146,6 +152,10 @@ end
 
 tools.camtrigger = {}
 tools.camtrigger.name = "Camtrigger"
+
+function tools.camtrigger.ondisabled()
+    project.selected_camtrigger = nil
+end
 
 function tools.camtrigger.draw()
     local ti, tj = mouseOverTile()

--- a/src/tools.lua
+++ b/src/tools.lua
@@ -5,8 +5,28 @@ toolslist = {"brush", "rectangle", "select", "camtrigger"}
 
 
 
-tools.brush = {}
-tools.brush.name = "Brush"
+baseTool = {}
+baseTool.__index = baseTool
+function baseTool.onenabled() end
+function baseTool.ondisabled() end
+function baseTool.update() end
+function baseTool.draw() end
+function baseTool.mousepressed() end
+function baseTool.mousereleased() end
+function baseTool.mousemoved() end
+
+function newTool(name)
+    local tool = {}
+    tool.name = name
+
+    setmetatable(tool, baseTool)
+
+    return tool
+end
+
+
+
+tools.brush = newTool("Brush")
 
 function tools.brush.update(dt)
     if not ui:windowIsAnyHovered() and not love.keyboard.isDown("lalt") and (love.mouse.isDown(1) or love.mouse.isDown(2)) then
@@ -34,8 +54,7 @@ end
 
 
 
-tools.rectangle = {}
-tools.rectangle.name = "Rectangle"
+tools.rectangle = newTool("Rectangle")
 
 function tools.rectangle.draw()
     local ti, tj = mouseOverTile()
@@ -93,8 +112,7 @@ end
 
 
 
-tools.select = {}
-tools.select.name = "Selection"
+tools.select = newTool("Selection")
 
 function tools.select.ondisabled()
     if project.selection then
@@ -150,8 +168,7 @@ end
 
 
 
-tools.camtrigger = {}
-tools.camtrigger.name = "Camtrigger"
+tools.camtrigger = newTool("Camera Trigger")
 
 function tools.camtrigger.ondisabled()
     project.selected_camtrigger = nil

--- a/src/util.lua
+++ b/src/util.lua
@@ -60,65 +60,65 @@ end
 local alph_ = "abcdefghijklmnopqrstuvwxyz"
 local alph = {[0] = " "}
 for i = 1, 26 do
-	alph[i] = string.sub(alph_, i, i)
+    alph[i] = string.sub(alph_, i, i)
 end
 
 function b26(n)
-	local m, n = math.floor(n / 26), n % 26
-	if m > 0 then
-		return b26(m - 1) .. alph[n + 1]
-	else
-		return alph[n + 1]
-	end
+    local m, n = math.floor(n / 26), n % 26
+    if m > 0 then
+        return b26(m - 1) .. alph[n + 1]
+    else
+        return alph[n + 1]
+    end
 end
 
 function loadroomdata(room, levelstr)
-	for i = 0, room.w - 1 do
-		for j = 0, room.h - 1 do
-			local k = i + j*room.w 
-			room.data[i][j] = fromhex(string.sub(levelstr, 1 + 2*k, 2 + 2*k))
-		end
-	end
+    for i = 0, room.w - 1 do
+        for j = 0, room.h - 1 do
+            local k = i + j*room.w
+            room.data[i][j] = fromhex(string.sub(levelstr, 1 + 2*k, 2 + 2*k))
+        end
+    end
 end
 
 function dumproomdata(room)
-	local s = ""
-	for j = 0, room.h - 1 do
-		for i = 0, room.w - 1 do
-			s = s .. tohex(room.data[i][j])
-		end
-	end
-	return s
+    local s = ""
+    for j = 0, room.h - 1 do
+        for i = 0, room.w - 1 do
+            s = s .. tohex(room.data[i][j])
+        end
+    end
+    return s
 end
 
 function roomMakeStr(room)
-	if room then
-		room.str = dumproomdata(room)
-	end
+    if room then
+        room.str = dumproomdata(room)
+    end
 end
 
 function roomMakeData(room)
-	if room then
-		room.data = fill2d0s(room.w, room.h)
-		loadroomdata(room, room.str)
-	end
+    if room then
+        room.data = fill2d0s(room.w, room.h)
+        loadroomdata(room, room.str)
+    end
 end
 
 function loadproject(str)
-	local proj = loadlua(str)
-	for n, room in pairs(proj.rooms) do
-		roomMakeData(room)
-	end
-	roomMakeData(proj.selection)
-	
-	return proj
+    local proj = loadlua(str)
+    for n, room in pairs(proj.rooms) do
+        roomMakeData(room)
+    end
+    roomMakeData(proj.selection)
+
+    return proj
 end
 
 function dumpproject(proj)
-	for n, room in pairs(proj.rooms) do
-		roomMakeStr(room)
-	end
-	roomMakeStr(proj.selection)
-	
-	return serpent.line(proj, {compact = true, comment = false, keyignore = {["data"] = true}})
+    for n, room in pairs(proj.rooms) do
+        roomMakeStr(room)
+    end
+    roomMakeStr(proj.selection)
+
+    return serpent.line(proj, {compact = true, comment = false, keyignore = {["data"] = true}})
 end


### PR DESCRIPTION
tools are now implemented in tools.lua using callbacks: onenabled (unused), ondisabled (used for removing selection/selected camtrigger), update, draw, mousepressed/released, mousemoved (unused). Keyboard shortcuts remain spaghetti for now

added drawColoredRect, it is now used for both selections and camtriggers

along the way added checks so rectangle and select don't crash the editor if you drag outside of the room

fixed intentation (did i mess it up myself? idk), anyway lets make sure to use 4 spaces from now on

pls check camtriggers work correctly, i moved most of their functionality into tools.lua (not all, some remains in keyboard.lua and rooms.lua) and modified some code slightly and also had a slight merge conflict so idk