### PR TITLE
added tool panels: used for camtrigger and new room properties tool

### DIFF
--- a/src/fileio.lua
+++ b/src/fileio.lua
@@ -74,7 +74,7 @@ function loadpico8(filename)
 
     for j =8,15 do
         for i = 0, 15 do
-            local id=i+16*(j-8) 
+            local id=i+16*(j-8)
             local d1=math.floor(id/16)
             local d2=id%16
             --spritesheet_data:paste(p8font,8*i,8*j,get_font_quad(d1))
@@ -136,6 +136,8 @@ function loadpico8(filename)
             levels, mapdata, camera_offsets = env.levels, env.mapdata, env.camera_offsets
         end
     end
+    -- parameter names default to none
+    data.param_names = data.param_names or {}
 
     mapdata = mapdata or {}
 
@@ -160,7 +162,7 @@ function loadpico8(filename)
             x, y, w, h, exits = tonumber(x), tonumber(y), tonumber(w), tonumber(h), exits or "0b0001"
             params=split(params or "")
             if x and y and w and h then -- this confirms they're there and they're numbers
-                data.rooms[n] = newRoom(x*128, y*128, w*16, h*16) 
+                data.rooms[n] = newRoom(x*128, y*128, w*16, h*16)
                 data.rooms[n].exits={left=exits:sub(3,3)=="1", bottom=exits:sub(4,4)=="1", right=exits:sub(5,5)=="1", top=exits:sub(6,6)=="1"}
                 data.rooms[n].hex=false
                 data.rooms[n].params=params
@@ -171,9 +173,10 @@ function loadpico8(filename)
     else
         for J = 0, 3 do
             for I = 0, 7 do
-                local b=newRoom(I*128, J*128, 16, 16)
+                local room=newRoom(I*128, J*128, 16, 16)
+                room.hex = false
                 --b.title=""
-                table.insert(data.rooms, b)
+                table.insert(data.rooms, room)
             end
         end
     end
@@ -206,7 +209,7 @@ function loadpico8(filename)
     end
 
     if camera_offsets then
-        for n,tbl in pairs(camera_offsets) do 
+        for n,tbl in pairs(camera_offsets) do
             for _,t in pairs(tbl) do
                 args={}
                 for d in t:gmatch("[%S^,]+") do
@@ -225,7 +228,7 @@ function openPico8(filename)
     newProject()
 
     -- loads into global p8data as well, for spritesheet
-    p8data = loadpico8(filename)    
+    p8data = loadpico8(filename)
     project.rooms = p8data.rooms
     --store names of parameters, in order to show in the ui
     project.param_names=p8data.param_names
@@ -278,20 +281,20 @@ function savePico8(filename)
                 exit_string=exit_string.."1"
             else
                 exit_string=exit_string.."0"
-            end 
-        end 
+            end
+        end
         levels[n] = string.format("%g,%g,%g,%g,%s", room.x/128, room.y/128, room.w/16, room.h/16, exit_string)
         for _,v in ipairs(room.params) do
             levels[n]=levels[n]..","..v
-        end 
+        end
 
-        if room.hex then 
+        if room.hex then
             mapdata[n] = dumproomdata(room)
         end
 
         if room.camtriggers then
             camera_offsets[n]={}
-            for _,t in pairs(room.camtriggers) do 
+            for _,t in pairs(room.camtriggers) do
                 local trigger_str=string.format("%d,%d,%d,%d,%d,%d",t.x,t.y,t.w,t.h,t.off_x,t.off_y)
                 table.insert(camera_offsets[n],trigger_str)
             end
@@ -318,20 +321,20 @@ function savePico8(filename)
         table.insert(out,"__map__")
     end
 
-    for k,v in ipairs(out) do 
-        if out[k]=="__gfx__" or out[k]=="__map__" then 
+    for k,v in ipairs(out) do
+        if out[k]=="__gfx__" or out[k]=="__map__" then
             local j=k+1
             while j<#out and not out[j]:match("__%a+__") do
                 j=j+1
-            end 
+            end
             local emptyline=""
-            for i=1,out[k]=="__gfx__" and 128 or 256 do 
+            for i=1,out[k]=="__gfx__" and 128 or 256 do
                 emptyline=emptyline.."0"
-            end 
-            for i=j,k+(out[k]=="__gfx__" and 128 or 32) do 
+            end
+            for i=j,k+(out[k]=="__gfx__" and 128 or 32) do
                 table.insert(out,i,emptyline)
             end
-        end 
+        end
     end
     local gfxstart, mapstart
     for k = 1, #out do

--- a/src/keyboard.lua
+++ b/src/keyboard.lua
@@ -197,11 +197,6 @@ function love.keypressed(key, scancode, isrepeat)
         return
     end
 
-    -- another fucking hack: the shit above doesnt consume inputs when editing text for some fucking reason
-    if app.editCamTrigger or app.editParams then
-        return
-    end
-
     -- now editing things (that shouldn't happen if you have a nuklear window focused or something)
 
     if key == "n" then
@@ -253,9 +248,6 @@ function love.keypressed(key, scancode, isrepeat)
                 end
             end
         end
-    elseif key == "t" and project.selected_camtrigger then
-        app.editCamtrigger=project.selected_camtrigger
-        app.editCamtriggerTable={x={value=project.selected_camtrigger.off_x},y={value=project.selected_camtrigger.off_y}}
     end
 end
 
@@ -265,20 +257,6 @@ function love.keyreleased(key, scancode)
 
     if ui:keyreleased(key, scancode) then
         return
-    end
-
-    -- this shortcut is handled on release, and can be consumed
-    -- so you don't input r into the field
-    if key == "r" and not love.keyboard.isDown("lctrl") and activeRoom() then
-        local room=activeRoom()
-        app.editParams = room
-        app.editParamsTable ={exits={},hex={value=room.hex},params={}}
-        for k,v in pairs(room.exits) do 
-            app.editParamsTable.exits[k]={value=v}
-        end
-        for i=1, math.max(#room.params, #project.param_names) do 
-            app.editParamsTable.params[i]={value=room.params[i] or 0}
-        end
     end
 end
 

--- a/src/mainloop.lua
+++ b/src/mainloop.lua
@@ -138,150 +138,29 @@ function love.update(dt)
         local tpw = 16*8*tms + 18
         if ui:windowBegin("Tool panel", app.W - tpw, 0, tpw, app.H) then
             -- tools list
-            for row = 0, math.ceil(#toolslist/4) - 1 do
-                ui:layoutRow("dynamic", 25*global_scale, 4)
+            for i = 0, #toolslist - 1 do
+                if i%4 == 0 then
+                    ui:layoutRow("dynamic", 25*global_scale, 4)
+                end
 
-                for i = 0, 3 do
-                    local tool = toolslist[1 + row*4+i]
+                local tool = toolslist[1 + i]
 
-                    if tool then
-                        if ui:selectable(tools[tool].name, app.tool == tool) then
-                            if app.tool and app.tool ~= tool then
-                                tools[app.tool].ondisabled()
+                if ui:selectable(tools[tool].name, app.tool == tool) then
+                    if app.tool and app.tool ~= tool then
+                        tools[app.tool].ondisabled()
 
-                                app.tool = tool
+                        app.tool = tool
 
-                                tools[app.tool].onenabled()
-                            end
-                        end
+                        tools[app.tool].onenabled()
                     end
                 end
             end
 
-            -- tiles
-            ui:layoutRow("dynamic", 25*global_scale, 1)
-            ui:label("Tiles:")
-            for j = 0, app.showGarbageTiles and 15 or 7 do
-                ui:layoutRow("static", 8*tms, 8*tms, 16)
-                for i = 0, 15 do
-                    local n = i + j*16
-                    if tileButton(n, app.currentTile == n and not app.autotile) then
-                        app.currentTile = n
-                        app.autotile = nil
-                    end
-                end
-            end
+            -- some spacing
+            ui:layoutRow("dynamic", 10*global_scale, 0)
 
-            -- autotiles
-            ui:layoutRow("dynamic", 25*global_scale, 1)
-            ui:label("Autotiles:")
-            ui:layoutRow("static", 8*tms, 8*tms, #autotiles)
-            for k, auto in ipairs(autotiles) do
-                if tileButton(auto[5], app.currentTile == auto[15] and app.autotile) then
-                    app.currentTile = auto[15]
-                    app.autotile = k
-                end
-            end
-        end
-        ui:windowEnd()
-    end
-
-    --if app.renameRoom then
-        --local room = app.renameRoom
-
-        --local w, h = 200*global_scale, 88*global_scale
-        --if ui:windowBegin("Rename room", app.W/2 - w/2, app.H/2 - h/2, w, h, {"title", "border", "closable", "movable"}) then
-            --ui:layoutRow("dynamic", 25*global_scale, 1)
-
-            --local state, changed
-            --ui:editFocus()
-            --state, changed = ui:edit("simple", app.renameRoomVTable)
-
-            --if ui:button("OK") or app.enterPressed then
-                --room.title = app.renameRoomVTable.value
-                --app.renameRoom = nil
-            --end
-        --else
-            --app.renameRoom = nil
-        --end
-        --ui:windowEnd()
-    --end
-    if app.editParams then
-        local room = app.editParams
-        local param_n = math.max(#project.param_names,#room.params)
-        local w, h = 500*global_scale, 125*global_scale + 25*param_n
-        if ui:windowBegin("Edit Room Parameters", app.W/2 - w/2, app.H/2 - h/2, w, h, {"title", "border", "closable", "movable"}) then
-
-            local x,y=div8(room.x),div8(room.y)
-            local fits_on_map=x>=0 and x+room.w<=128 and y>=0 and y+room.h<=64
-            ui:layoutRow("dynamic",25*global_scale,1)
-            if not fits_on_map then
-                local style={}
-                for k,v in pairs({"text normal", "text hover", "text active"}) do
-                    style[v]="#707070"
-                end
-                for k,v in pairs({"normal", "hover", "active"}) do
-                    style[v]=checkmarkWithBg -- show both selected and unselected as having a check to avoid nukelear limitations
-                    -- kinda hacky but it works decently enough
-                end
-                ui:stylePush({['checkbox']=style})
-
-            else
-                ui:stylePush({})
-            end
-            ui:checkbox("Level Stored As Hex",fits_on_map and app.editParamsTable.hex or true)
-            ui:stylePop()
-
-
-            ui:layoutRow("dynamic", 25*global_scale, 5)
-            ui:label("Level Exits:")
-            for _,v in pairs({"left","bottom","right","top"}) do
-                ui:checkbox(v,app.editParamsTable.exits[v])
-            end 
-
-            for i=1, param_n do 
-                ui:layoutRow("dynamic", 25*global_scale, {0.25,0.75} )
-                ui:label(project.param_names[i] or "")
-                ui:edit("field", app.editParamsTable.params[i])
-            end
-            ui:layoutRow("dynamic",25*global_scale,1)
-            if ui:button("OK") or app.enterPressed then
-                --room.params.test=app.editParamsVTable.test.value
-                --print(room.params.test)
-                app.editParams.hex=app.editParamsTable.hex.value
-                for k,v in pairs(app.editParamsTable.exits) do
-                    app.editParams.exits[k]=v.value
-                end
-                for k,v in pairs(app.editParamsTable.params) do 
-                    app.editParams.params[k]=v.value
-                end
-                app.editParams = nil
-            end
-        else
-            app.editParams = nil
-        end
-        ui:windowEnd()
-    end
-    if app.editCamtrigger then
-        local room = app.editParams
-
-        local w, h = 400*global_scale, 88*global_scale
-        if ui:windowBegin("Edit Camera Triggers", app.W/2 - w/2, app.H/2 - h/2, w, h, {"title", "border", "closable", "movable"}) then
-            ui:layoutRow("dynamic",25*global_scale,4)
-            ui:label("x offset","centered")
-            ui:edit("simple",app.editCamtriggerTable.x)
-            ui:label("y offset","centered")
-            ui:edit("simple",app.editCamtriggerTable.y)
-            ui:layoutRow("dynamic",25*global_scale,1)
-            if ui:button("OK") or app.enterPressed then
-                --room.params.test=app.editParamsVTable.test.value
-                --print(room.params.test)
-                app.editCamtrigger.off_x=app.editCamtriggerTable.x.value
-                app.editCamtrigger.off_y=app.editCamtriggerTable.y.value
-                app.editCamtrigger = nil
-            end
-        else
-            app.editCamtrigger=nil
+            -- tool panel
+            tools[app.tool].panel()
         end
         ui:windowEnd()
     end


### PR DESCRIPTION
tools now have a panel() callback that defines the widgets that are displayed in the side panel. Brush and Rectangle display the old tiles list, Selection displays nothing, Camera Trigger displays selected trigger's properties, new tool Room Properties displays selected room's properties.

both dialogs have been deleted

substantially simplified edit widgets: apparently you don't need to keep track of tables (like editParamsTable), you can just create a temporary table before calling :edit(), also checkboxes don't need tables at all, (also a ternary operator you used for one of the checkboxes didn't work correctly, a and b or c doesn't work if b is false)

no idea if room parameters work correctly yet